### PR TITLE
fix: Set matplotlib backend for MacOS

### DIFF
--- a/imcui/ui/viz.py
+++ b/imcui/ui/viz.py
@@ -39,6 +39,9 @@ def plot_images(
     n = len(imgs)
     if not isinstance(cmaps, list):
         cmaps = [cmaps] * n
+        
+    plt.switch_backend('module://matplotlib_inline.backend_inline')
+    
     figsize = (size * n, size * 6 / 5) if size is not None else None
     fig, ax = plt.subplots(1, n, figsize=figsize, dpi=dpi)
 

--- a/imcui/ui/viz.py
+++ b/imcui/ui/viz.py
@@ -39,9 +39,9 @@ def plot_images(
     n = len(imgs)
     if not isinstance(cmaps, list):
         cmaps = [cmaps] * n
-        
-    plt.switch_backend('module://matplotlib_inline.backend_inline')
-    
+
+    plt.switch_backend("module://matplotlib_inline.backend_inline")
+
     figsize = (size * n, size * 6 / 5) if size is not None else None
     fig, ax = plt.subplots(1, n, figsize=figsize, dpi=dpi)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Jinja2
 kornia
 loguru
 matplotlib<3.9
+matplotlib-inline
 numpy~=1.26
 omegaconf
 onnxruntime
@@ -20,7 +21,6 @@ opencv-python
 pandas
 plotly
 poselib
-matplotlib-inline
 protobuf
 psutil
 pycolmap==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ opencv-python
 pandas
 plotly
 poselib
+matplotlib-inline
 protobuf
 psutil
 pycolmap==0.6.1


### PR DESCRIPTION
Added plt.switch_backend() call to ensure proper rendering on MacOS systems.
This resolves display issues when running matplotlib in notebook environments.