### PR TITLE
Fix gradio 6 compatibility

### DIFF
--- a/imcui/ui/app_class.py
+++ b/imcui/ui/app_class.py
@@ -76,7 +76,7 @@ class ImageMatchingApp:
                             str(Path(__file__).parent.parent / "assets/logo.webp"),
                             elem_id="logo-img",
                             show_label=False,
-                            buttons=['fullscreen']
+                            buttons=["fullscreen"],
                         )
                     with gr.Column(scale=3):
                         gr.Markdown(DESCRIPTION)


### PR DESCRIPTION
## Description

Migrated from Gradio 5.x to Gradio 6.x following the [migration guide](https://www.gradio.app/main/guides/gradio-6-migration-guide).

### Changes Made

#### **File**: `imcui/ui/app_class.py`
- **CSS Parameter**: Moved `css=CSS` from `gr.Blocks()` constructor to `launch()` method 
- **Dataframe Parameters**: Updated `gr.Dataframe` component parameters
- **Image Parameters**: Removed ` show_share_button, show_download_button` parameter from `gr.Image` (deprecated in Gradio 6)
