### PR TITLE
feat: add MINIMA weights for LightGlue, ELoFTR, and XoFTR (#144)

### DIFF
--- a/config/app.yaml
+++ b/config/app.yaml
@@ -118,6 +118,39 @@ matcher_zoo:
       github: https://github.com/LSXI7/MINIMA
       display: true
       efficiency: low  # low, medium, high
+  minima(lightglue):
+    matcher: minima_lightglue
+    feature: superpoint_max
+    standalone: false
+    info:
+      name: MINIMA(LightGlue) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: high  # low, medium, high
+  minima(eloftr):
+    matcher: minima_eloftr
+    standalone: true
+    skip_ci: true
+    info:
+      name: MINIMA(ELoFTR) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: medium  # low, medium, high
+  minima(xoftr):
+    matcher: minima_xoftr
+    standalone: true
+    skip_ci: true
+    info:
+      name: MINIMA(XoFTR) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: medium  # low, medium, high
   omniglue:
     enable: true
     matcher: omniglue

--- a/imcui/config/app.yaml
+++ b/imcui/config/app.yaml
@@ -118,6 +118,39 @@ matcher_zoo:
       github: https://github.com/LSXI7/MINIMA
       display: true
       efficiency: low  # low, medium, high
+  minima(lightglue):
+    matcher: minima_lightglue
+    feature: superpoint_max
+    standalone: false
+    info:
+      name: MINIMA(LightGlue) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: high  # low, medium, high
+  minima(eloftr):
+    matcher: minima_eloftr
+    standalone: true
+    skip_ci: true
+    info:
+      name: MINIMA(ELoFTR) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: medium  # low, medium, high
+  minima(xoftr):
+    matcher: minima_xoftr
+    standalone: true
+    skip_ci: true
+    info:
+      name: MINIMA(XoFTR) #dispaly name
+      source: "ARXIV 2024"
+      paper: https://arxiv.org/abs/2412.19412
+      github: https://github.com/LSXI7/MINIMA
+      display: true
+      efficiency: medium  # low, medium, high
   omniglue:
     enable: true
     matcher: omniglue

--- a/imcui/hloc/configs/matchers.py
+++ b/imcui/hloc/configs/matchers.py
@@ -82,6 +82,23 @@ confs = {
             "force_resize": False,
         },
     },
+    "minima_lightglue": {
+        "output": "matches-minima_lightglue",
+        "model": {
+            "name": "lightglue",
+            "match_threshold": 0.2,
+            "width_confidence": 0.99,
+            "depth_confidence": 0.95,
+            "features": "superpoint",
+            "model_name": "minima_lightglue.pth",
+        },
+        "preprocessing": {
+            "grayscale": True,
+            "resize_max": 1024,
+            "dfactor": 8,
+            "force_resize": False,
+        },
+    },
     "raco-lightglue": {
         "output": "matches-raco-lightglue",
         "model": {
@@ -249,6 +266,25 @@ confs = {
         "max_error": 1,  # max error for assigned keypoints (in px)
         "cell_size": 1,  # size of quantization patch (max 1 kp/patch)
     },
+    "minima_eloftr": {
+        "output": "matches-minima_eloftr",
+        "model": {
+            "name": "eloftr",
+            "model_name": "minima_eloftr.ckpt",
+            "max_keypoints": 2000,
+            "match_threshold": 0.2,
+        },
+        "preprocessing": {
+            "grayscale": True,
+            "resize_max": 1024,
+            "dfactor": 32,
+            "width": 640,
+            "height": 480,
+            "force_resize": True,
+        },
+        "max_error": 1,
+        "cell_size": 1,
+    },
     "xoftr": {
         "output": "matches-xoftr",
         "model": {
@@ -267,6 +303,25 @@ confs = {
         },
         "max_error": 1,  # max error for assigned keypoints (in px)
         "cell_size": 1,  # size of quantization patch (max 1 kp/patch)
+    },
+    "minima_xoftr": {
+        "output": "matches-minima_xoftr",
+        "model": {
+            "name": "xoftr",
+            "weights": "minima_xoftr.ckpt",
+            "max_keypoints": 2000,
+            "match_threshold": 0.3,
+        },
+        "preprocessing": {
+            "grayscale": True,
+            "resize_max": 1024,
+            "dfactor": 8,
+            "width": 640,
+            "height": 480,
+            "force_resize": True,
+        },
+        "max_error": 1,
+        "cell_size": 1,
     },
     "jamma": {
         "output": "matches-jamma",


### PR DESCRIPTION
## Summary

Adds the three remaining MINIMA model variants to complete full MINIMA support:

| Variant | Pipeline | Config |
|---------|----------|--------|
| `minima(lightglue)` | SuperPoint → MINIMA LightGlue (sparse) | `standalone: false, feature: superpoint_max` |
| `minima(eloftr)` | MINIMA EfficientLoFTR (standalone) | `standalone: true` |
| `minima(xoftr)` | MINIMA XoFTR (standalone) | `standalone: true` |

### Weights uploaded to HF

- `loftr/minima_loftr.ckpt` (updated)
- `eloftr/minima_eloftr.ckpt` (new)
- `xoftr/minima_xoftr.ckpt` (new)
- `lightglue/minima_lightglue.pth` (already existed)

### Files changed

- `imcui/hloc/configs/matchers.py` — 3 new config entries
- `config/app.yaml` — 3 new matcher_zoo entries
- `imcui/config/app.yaml` — synced

## Closes

- Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)