### PR TITLE
fix: LISRD matcher bug + paper-style visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cmake_modules/
 cmake-build-debug/
 .idea/
 .vscode/
+.venv
 *.pyc
 flagged
 .ipynb_checkpoints
@@ -31,6 +32,10 @@ datasets/South-Building*
 *.pkl
 oryx-build-commands.txt
 .ruff_cache*
+.pytest_cache*
+.ruff_cache*
+.mypy_cache*
+*_cache*
 dist
 tmp
 **.DS_Store**

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -700,24 +700,36 @@ matcher_zoo:
       project: https://feixue94.github.io/
       display: true
 
-  LISRD(ViDiT):
-    matcher: lisrd-vidit
+  LISRD+SuperPoint:
+    matcher: lisrd-superpoint
     standalone: true
     skip_ci: true
     info:
-      name: LISRD(ViDiT)
+      name: LISRD+SuperPoint
       source: "ECCV 2020"
       github: https://github.com/rpautrat/LISRD
       paper: https://arxiv.org/abs/2007.08988
       display: true
       efficiency: medium
 
-  LISRD(Aachen):
-    matcher: lisrd-aachen
+  LISRD+ALIKED:
+    matcher: lisrd-aliked
     standalone: true
     skip_ci: true
     info:
-      name: LISRD(Aachen)
+      name: LISRD+ALIKED
+      source: "ECCV 2020"
+      github: https://github.com/rpautrat/LISRD
+      paper: https://arxiv.org/abs/2007.08988
+      display: true
+      efficiency: medium
+
+  LISRD+SIFT:
+    matcher: lisrd-sift
+    standalone: true
+    skip_ci: true
+    info:
+      name: LISRD+SIFT
       source: "ECCV 2020"
       github: https://github.com/rpautrat/LISRD
       paper: https://arxiv.org/abs/2007.08988

--- a/imcui/config/app.yaml
+++ b/imcui/config/app.yaml
@@ -700,24 +700,36 @@ matcher_zoo:
       project: https://feixue94.github.io/
       display: true
 
-  LISRD(ViDiT):
-    matcher: lisrd-vidit
+  LISRD+SuperPoint:
+    matcher: lisrd-superpoint
     standalone: true
     skip_ci: true
     info:
-      name: LISRD(ViDiT)
+      name: LISRD+SuperPoint
       source: "ECCV 2020"
       github: https://github.com/rpautrat/LISRD
       paper: https://arxiv.org/abs/2007.08988
       display: true
       efficiency: medium
 
-  LISRD(Aachen):
-    matcher: lisrd-aachen
+  LISRD+ALIKED:
+    matcher: lisrd-aliked
     standalone: true
     skip_ci: true
     info:
-      name: LISRD(Aachen)
+      name: LISRD+ALIKED
+      source: "ECCV 2020"
+      github: https://github.com/rpautrat/LISRD
+      paper: https://arxiv.org/abs/2007.08988
+      display: true
+      efficiency: medium
+
+  LISRD+SIFT:
+    matcher: lisrd-sift
+    standalone: true
+    skip_ci: true
+    info:
+      name: LISRD+SIFT
       source: "ECCV 2020"
       github: https://github.com/rpautrat/LISRD
       paper: https://arxiv.org/abs/2007.08988

--- a/imcui/hloc/configs/matchers.py
+++ b/imcui/hloc/configs/matchers.py
@@ -798,12 +798,13 @@ confs = {
             "dfactor": 8,
         },
     },
-    "lisrd-vidit": {
-        "output": "matches-lisrd-vidit",
+    "lisrd-superpoint": {
+        "output": "matches-lisrd-superpoint",
         "model": {
             "name": "lisrd",
-            "model_name": "lisrd_vidit",
+            "model_name": "lisrd_aachen",
             "max_keypoints": 2048,
+            "detector": "superpoint",
         },
         "preprocessing": {
             "grayscale": False,
@@ -814,12 +815,30 @@ confs = {
             "dfactor": 8,
         },
     },
-    "lisrd-aachen": {
-        "output": "matches-lisrd-aachen",
+    "lisrd-aliked": {
+        "output": "matches-lisrd-aliked",
         "model": {
             "name": "lisrd",
             "model_name": "lisrd_aachen",
             "max_keypoints": 2048,
+            "detector": "aliked",
+        },
+        "preprocessing": {
+            "grayscale": False,
+            "force_resize": True,
+            "resize_max": 1024,
+            "width": 640,
+            "height": 480,
+            "dfactor": 8,
+        },
+    },
+    "lisrd-sift": {
+        "output": "matches-lisrd-sift",
+        "model": {
+            "name": "lisrd",
+            "model_name": "lisrd_aachen",
+            "max_keypoints": 2048,
+            "detector": "sift",
         },
         "preprocessing": {
             "grayscale": False,

--- a/imcui/hloc/matchers/lisrd.py
+++ b/imcui/hloc/matchers/lisrd.py
@@ -12,12 +12,14 @@ References:
 import sys
 from pathlib import Path
 
-import cv2
-import numpy as np
 import torch
 import torch.nn.functional as F
+from kornia.color import rgb_to_grayscale
 
 from .. import logger
+from ..extractors.aliked import ALIKED as ALIKEDExtractor
+from ..extractors.sift import SIFT as SIFTExtractor
+from ..extractors.superpoint import SuperPoint as SuperPointExtractor
 from ..utils.base_model import BaseModel
 
 lisrd_path = Path(__file__).parent / "../../third_party/LISRD"
@@ -39,11 +41,36 @@ LISRD_CONFIG: dict = {
     "freeze_local_desc": False,
 }
 
+# Available keypoint detectors with their default configs.
+_DETECTOR_BUILDERS = {
+    "superpoint": lambda max_kpts: SuperPointExtractor(
+        {
+            "nms_radius": 4,
+            "model_name": "superpoint_v1.pth",
+            "keypoint_threshold": 0.005,
+            "max_keypoints": max_kpts,
+            "remove_borders": 4,
+        }
+    ),
+    "aliked": lambda max_kpts: ALIKEDExtractor(
+        {
+            "name": "aliked",
+            "model_name": "aliked-n16",
+            "max_num_keypoints": max_kpts,
+            "detection_threshold": 0.2,
+        }
+    ),
+    "sift": lambda max_kpts: SIFTExtractor(
+        {
+            "max_keypoints": max_kpts,
+            "backend": "opencv",
+        }
+    ),
+}
+
 
 # ---------------------------------------------------------------------------
 # Inlined helpers from LISRD's geometry_utils and pytorch_utils.
-# We inline these to avoid importing lisrd.utils.geometry_utils, which pulls in
-# homographies → keypoint_detectors → super_point_magic_leap (unused here).
 # ---------------------------------------------------------------------------
 
 
@@ -62,8 +89,6 @@ def _keypoints_to_grid(keypoints, img_size):
 
 def _extract_descriptors(keypoints, descriptors, meta_descriptors, img_size):
     """Sample dense descriptor maps at keypoint locations.
-
-    Adapted from ``lisrd.utils.geometry_utils.extract_descriptors``.
 
     Args:
         keypoints: ``(N, 2)`` tensor in (row, col) pixel coordinates.
@@ -95,15 +120,10 @@ def _extract_descriptors(keypoints, descriptors, meta_descriptors, img_size):
 
 
 def _lisrd_matcher(desc1, desc2, meta_desc1, meta_desc2):
-    """Mutual nearest neighbour matching via meta-weighted descriptor similarity.
-
-    Adapted from ``lisrd.utils.geometry_utils.lisrd_matcher``.
-    """
+    """Mutual nearest neighbour matching via meta-weighted descriptor similarity."""
     device = desc1.device
-    # (N1, N2, 4) — per-variance meta similarity
     desc_weights = torch.einsum("nid,mid->nim", meta_desc1, meta_desc2)
     desc_weights = F.softmax(desc_weights, dim=1)
-    # (N1, N2, 4) — per-variance descriptor similarity
     desc_sims = torch.einsum("nid,mid->nim", desc1, desc2) * desc_weights
     desc_sims = torch.sum(desc_sims, dim=1)  # (N1, N2)
 
@@ -114,6 +134,21 @@ def _lisrd_matcher(desc1, desc2, meta_desc1, meta_desc2):
     return torch.stack([ids1[mask], nn12[mask]], dim=1)
 
 
+def _compute_confidence(desc0, desc1, meta0, meta1):
+    """Meta-descriptor weighted cosine similarity for matched pairs."""
+    desc0 = F.normalize(desc0, dim=2)
+    desc1 = F.normalize(desc1, dim=2)
+    meta0 = F.normalize(meta0, dim=2)
+    meta1 = F.normalize(meta1, dim=2)
+
+    desc_sim = torch.sum(desc0 * desc1, dim=2)  # (M, 4)
+    meta_sim = torch.sum(meta0 * meta1, dim=2)  # (M, 4)
+
+    weights = F.softmax(meta_sim, dim=1)
+    confidence = torch.sum(desc_sim * weights, dim=1)  # (M,)
+    return confidence
+
+
 # ---------------------------------------------------------------------------
 # Matcher class
 # ---------------------------------------------------------------------------
@@ -122,15 +157,17 @@ def _lisrd_matcher(desc1, desc2, meta_desc1, meta_desc2):
 class Lisrd(BaseModel):
     """LISRD standalone matcher.
 
-    Internally detects SIFT keypoints, extracts LISRD descriptors with four
-    invariance combinations, and matches them via mutual nearest neighbour
-    weighted by meta-descriptor similarity.
+    Detects keypoints with a configurable detector (SuperPoint, ALIKED, or
+    SIFT), extracts LISRD descriptors with four invariance combinations, and
+    matches them via mutual nearest neighbour weighted by meta-descriptor
+    similarity.
     """
 
     default_conf = {
         "name": "two_view_pipeline",
-        "model_name": "lisrd_vidit",
+        "model_name": "lisrd_aachen",
         "max_keypoints": 2048,
+        "detector": "superpoint",  # "superpoint", "aliked", or "sift"
     }
     required_inputs = [
         "image0",
@@ -152,21 +189,74 @@ class Lisrd(BaseModel):
         self.net._net.eval()
         logger.info("Load LISRD model done.")
 
-    def _forward(self, data):
-        num_keypoints = self.conf["max_keypoints"]
+        # ---- Keypoint detector -----------------------------------------------
+        detector_name = self.conf.get("detector", "superpoint")
+        if detector_name not in _DETECTOR_BUILDERS:
+            raise ValueError(
+                f"Unknown LISRD detector: {detector_name}. "
+                f"Choose from {list(_DETECTOR_BUILDERS.keys())}."
+            )
+        self.detector = _DETECTOR_BUILDERS[detector_name](self.conf["max_keypoints"])
+        # GPU-capable detectors run on the LISRD device; SIFT stays on CPU.
+        if detector_name != "sift":
+            self.detector.to(self.device)
+        logger.info(f"LISRD detector: {detector_name}")
 
-        # WebUI delivers images as float32 [0, 1]; LISRD expects [0, 255].
+    def _forward(self, data):
+        detector_name = self.conf.get("detector", "superpoint")
+
+        # LISRD expects [0, 255]; WebUI delivers [0, 1].
         img0 = data["image0"] * 255.0
         img1 = data["image1"] * 255.0
         h0, w0 = img0.shape[2], img0.shape[3]
         h1, w1 = img1.shape[2], img1.shape[3]
 
-        with torch.no_grad():
-            # -- 1. Detect keypoints with OpenCV SIFT ------------------------
-            kp0 = self._detect_sift_keypoints(img0, num_keypoints)
-            kp1 = self._detect_sift_keypoints(img1, num_keypoints)
+        # Detector images stay in [0, 1].
+        det_img0 = data["image0"]
+        det_img1 = data["image1"]
 
-            # -- 2. Extract LISRD descriptors --------------------------------
+        with torch.no_grad():
+            # -- 1. Detect keypoints -------------------------------------------
+            if detector_name in ("superpoint", "aliked"):
+                # SuperPoint needs grayscale; ALIKED handles RGB natively.
+                if detector_name == "superpoint":
+                    if det_img0.shape[1] == 3:
+                        det_img0 = rgb_to_grayscale(det_img0)
+                    if det_img1.shape[1] == 3:
+                        det_img1 = rgb_to_grayscale(det_img1)
+
+                kp_out0 = self.detector({"image": det_img0.to(self.device)})
+                kp_out1 = self.detector({"image": det_img1.to(self.device)})
+                kps0 = kp_out0["keypoints"]
+                kps1 = kp_out1["keypoints"]
+
+                # ALIKED returns a list of per-image tensors.
+                if isinstance(kps0, list):
+                    kps0, kps1 = kps0[0], kps1[0]
+
+                # Guard against zero keypoints.
+                if kps0.numel() == 0:
+                    kps0 = torch.zeros(0, 2, device=self.device)
+                if kps1.numel() == 0:
+                    kps1 = torch.zeros(0, 2, device=self.device)
+                if kps0.dim() == 1:
+                    kps0 = kps0.view(-1, 2)
+                if kps1.dim() == 1:
+                    kps1 = kps1.view(-1, 2)
+            else:
+                # SIFT (CPU-based OpenCV).
+                kp_out0 = self.detector({"image": det_img0})
+                kp_out1 = self.detector({"image": det_img1})
+                # SIFT extractor returns (B, N, 2); B=1 here.
+                kps0 = kp_out0["keypoints"][0].to(self.device)
+                kps1 = kp_out1["keypoints"][0].to(self.device)
+
+            # All detectors return keypoints in (x, y).  Convert to (row, col)
+            # for _extract_descriptors, which matches the original LISRD API.
+            gpu_kp0 = kps0[:, [1, 0]]
+            gpu_kp1 = kps1[:, [1, 0]]
+
+            # -- 2. Extract LISRD descriptors -----------------------------------
             inputs0 = {"image0": img0.to(self.device)}
             outputs0 = self.net._forward(inputs0, Mode.EXPORT, LISRD_CONFIG)
             desc0 = outputs0["descriptors"]
@@ -177,10 +267,7 @@ class Lisrd(BaseModel):
             desc1 = outputs1["descriptors"]
             meta_desc1 = outputs1["meta_descriptors"]
 
-            # -- 3. Sample descriptors at keypoint locations -----------------
-            gpu_kp0 = torch.tensor(kp0[:, :2], dtype=torch.float, device=self.device)
-            gpu_kp1 = torch.tensor(kp1[:, :2], dtype=torch.float, device=self.device)
-
+            # -- 3. Sample descriptors at keypoint locations ---------------------
             sampled_desc0, sampled_meta0 = _extract_descriptors(
                 gpu_kp0, desc0, meta_desc0, (h0, w0)
             )
@@ -188,12 +275,12 @@ class Lisrd(BaseModel):
                 gpu_kp1, desc1, meta_desc1, (h1, w1)
             )
 
-            # -- 4. Mutual nearest neighbour matching ------------------------
+            # -- 4. Mutual nearest neighbour matching ----------------------------
             matches = _lisrd_matcher(
-                sampled_desc0, sampled_meta0, sampled_desc1, sampled_meta1
+                sampled_desc0, sampled_desc1, sampled_meta0, sampled_meta1
             )
 
-            # -- 5. Confidence from meta-weighted descriptor similarity ------
+            # -- 5. Confidence --------------------------------------------------
             idx0, idx1 = matches[:, 0], matches[:, 1]
             mconf = _compute_confidence(
                 sampled_desc0[idx0],
@@ -202,10 +289,10 @@ class Lisrd(BaseModel):
                 sampled_meta1[idx1],
             )
 
-        # -- 6. Pack outputs (coordinates in pixel space, (x,y) = (col,row))
-        # kp is (row, col, response); swap to (x, y).
-        all_kpts0 = torch.tensor(kp0[:, [1, 0]], dtype=torch.float, device=self.device)
-        all_kpts1 = torch.tensor(kp1[:, [1, 0]], dtype=torch.float, device=self.device)
+        # -- 6. Pack outputs ----------------------------------------------------
+        # kps0/kps1 are already in (x, y) format.
+        all_kpts0 = kps0
+        all_kpts1 = kps1
 
         matched_kpts0 = all_kpts0[idx0]
         matched_kpts1 = all_kpts1[idx1]
@@ -217,52 +304,3 @@ class Lisrd(BaseModel):
             "mkeypoints1": matched_kpts1,
             "mconf": mconf,
         }
-
-    @staticmethod
-    def _detect_sift_keypoints(img_tensor, num_keypoints):
-        """OpenCV SIFT keypoint detection.
-
-        Args:
-            img_tensor: ``(1, 3, H, W)`` float32 tensor in [0, 255].
-            num_keypoints: maximum number of keypoints.
-
-        Returns:
-            ``np.ndarray`` of shape ``(N, 3)`` with columns (row, col, response).
-        """
-        img_np = img_tensor[0].cpu().numpy().transpose(1, 2, 0)  # HWC
-        img_np = np.uint8(img_np)
-        gray = cv2.cvtColor(img_np, cv2.COLOR_RGB2GRAY)
-
-        sift = cv2.SIFT_create(nfeatures=num_keypoints, contrastThreshold=0.01)
-        keypoints = sift.detect(gray, None)
-
-        if len(keypoints) == 0:
-            return np.array([[0.0, 0.0, 0.0]], dtype=np.float32)
-
-        return np.array(
-            [[k.pt[1], k.pt[0], k.response] for k in keypoints],
-            dtype=np.float32,
-        )
-
-
-def _compute_confidence(desc0, desc1, meta0, meta1):
-    """Meta-descriptor weighted cosine similarity for matched pairs.
-
-    Args:
-        desc0, desc1: ``(M, 4, D)`` — descriptors per invariance type.
-        meta0, meta1: ``(M, 4, D')`` — meta descriptors per invariance type.
-
-    Returns:
-        ``(M,)`` tensor of confidence scores.
-    """
-    desc0 = F.normalize(desc0, dim=2)
-    desc1 = F.normalize(desc1, dim=2)
-    meta0 = F.normalize(meta0, dim=2)
-    meta1 = F.normalize(meta1, dim=2)
-
-    desc_sim = torch.sum(desc0 * desc1, dim=2)  # (M, 4)
-    meta_sim = torch.sum(meta0 * meta1, dim=2)  # (M, 4)
-
-    weights = F.softmax(meta_sim, dim=1)
-    confidence = torch.sum(desc_sim * weights, dim=1)  # (M,)
-    return confidence

--- a/imcui/hloc/utils/viz.py
+++ b/imcui/hloc/utils/viz.py
@@ -20,26 +20,55 @@ def cm_RdGn(x):
 
 
 def plot_images(
-    imgs, titles=None, cmaps="gray", dpi=100, pad=0.5, adaptive=True, figsize=4.5
+    imgs, titles=None, cmaps="gray", dpi=100, pad=0.0, adaptive=True, figsize=4.5
 ):
-    """Plot a set of images horizontally.
+    """Plot a set of images horizontally with minimal whitespace (paper-style).
+
+    Figure size is computed from image pixel dimensions.  A fixed top margin
+    (0.25") is reserved for titles so they never get clipped.
+
     Args:
         imgs: a list of NumPy or PyTorch images, RGB (H, W, 3) or mono (H, W).
-        titles: a list of strings, as titles for each image.
+        titles: a list of strings, placed in the top margin above each image.
         cmaps: colormaps for monochrome images.
         adaptive: whether the figure size should fit the image aspect ratios.
+        pad: deprecated (ignored).
+        figsize: figure height in inches (used as base when adaptive=False).
     """
     n = len(imgs)
     if not isinstance(cmaps, (list, tuple)):
         cmaps = [cmaps] * n
+    if isinstance(titles, str):
+        titles = [titles]
+
+    # Fixed top margin in inches so titles are never clipped
+    TITLE_MARGIN_INCHES = 0.25
+    heights = [img.shape[0] for img in imgs]
+    widths = [img.shape[1] for img in imgs]
+    max_h = max(heights)
+    total_w = sum(widths)
 
     if adaptive:
         ratios = [i.shape[1] / i.shape[0] for i in imgs]  # W / H
     else:
         ratios = [4 / 3] * n
-    figsize = [sum(ratios) * figsize, figsize]
+
+    axes_h = max_h / dpi
+    fig_h = axes_h + TITLE_MARGIN_INCHES
+    top = axes_h / fig_h
+    figsize_computed = (total_w / dpi, fig_h)
+
+    if not adaptive:
+        # Use user-supplied figsize as base height
+        figsize_computed = (sum(ratios) * figsize, figsize + TITLE_MARGIN_INCHES)
+        top = figsize / figsize_computed[1]
+
     fig, axs = plt.subplots(
-        1, n, figsize=figsize, dpi=dpi, gridspec_kw={"width_ratios": ratios}
+        1,
+        n,
+        figsize=figsize_computed,
+        dpi=dpi,
+        gridspec_kw={"width_ratios": ratios},
     )
     if n == 1:
         axs = [axs]
@@ -47,8 +76,9 @@ def plot_images(
         ax.imshow(img, cmap=plt.get_cmap(cmaps[i]))
         ax.set_axis_off()
         if titles:
-            ax.set_title(titles[i])
-    fig.tight_layout(pad=pad)
+            ax.set_title(titles[i], pad=2, fontsize=9)
+
+    plt.subplots_adjust(left=0, right=1, bottom=0, top=top, wspace=0.005, hspace=0)
     return fig
 
 

--- a/imcui/ui/viz.py
+++ b/imcui/ui/viz.py
@@ -1,9 +1,11 @@
 import typing
+import io
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import cv2
 import matplotlib
+import matplotlib.patheffects as path_effects
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -14,33 +16,86 @@ np.random.seed(1995)
 color_map = np.arange(100)
 np.random.shuffle(color_map)
 
+# Fixed top margin for titles (inches) so text never gets clipped
+_TITLE_MARGIN_INCHES = 0.25
+# Small gap between subplots
+_WSPACE = 0.005
+
+
+def _figure_size_for_images(
+    images: List[np.ndarray],
+    dpi: int,
+    ncols: int = 1,
+    title_margin_inches: float = _TITLE_MARGIN_INCHES,
+) -> Tuple[Tuple[float, float], float, List[float]]:
+    """Compute figure size, axes ``top`` fraction, and width ratios.
+
+    Each subplot's width is proportional to its image's aspect ratio so
+    every image fills its subplot without side-whitespace, even when the
+    two images have different dimensions.
+
+    A minimum figure width ensures high-PPI output.
+    """
+    MIN_FIG_WIDTH = 14.0  # inches — at 300 dpi → 4200 px wide output
+
+    heights = [img.shape[0] for img in images]
+    widths = [img.shape[1] for img in images]
+    max_h = max(heights)
+
+    # Subplot width ratios = individual image W/H (aspect ratios).
+    width_ratios = [w / h for w, h in zip(widths, heights)]
+
+    # Natural size — images at 1:1 pixel mapping.
+    axes_h = max_h / dpi
+    natural_fig_w = axes_h * sum(width_ratios)
+    if natural_fig_w < MIN_FIG_WIDTH:
+        scale = MIN_FIG_WIDTH / natural_fig_w
+        axes_h *= scale  # keep subplot AR == image AR
+
+    fig_w = max(natural_fig_w, MIN_FIG_WIDTH)
+    fig_h = axes_h + title_margin_inches
+    top = axes_h / fig_h
+
+    return (fig_w, fig_h), top, width_ratios
+
+
+def _stroked_text(ax, x, y, text, fontsize=12, color="w", lw=2, **kwargs):
+    """Add text with a dark outline so it is readable on any background."""
+    t = ax.text(
+        x, y, text, fontsize=fontsize, color=color, transform=ax.transAxes, **kwargs
+    )
+    t.set_path_effects(
+        [
+            path_effects.Stroke(linewidth=lw, foreground="k"),
+            path_effects.Normal(),
+        ]
+    )
+    return t
+
 
 def plot_images(
     imgs: List[np.ndarray],
     titles: Optional[List[str]] = None,
     cmaps: Union[str, List[str]] = "gray",
     dpi: int = 100,
-    size: Optional[int] = 5,
-    pad: float = 0.5,
+    size: Optional[int] = None,
+    pad: float = 0.0,
 ) -> plt.Figure:
-    """Plot a set of images horizontally.
-    Args:
-        imgs: a list of NumPy or PyTorch images, RGB (H, W, 3) or mono (H, W).
-        titles: a list of strings, as titles for each image.
-        cmaps: colormaps for monochrome images. If a single string is given,
-            it is used for all images.
-        dpi: DPI of the figure.
-        size: figure size in inches (width). If not provided, the figure
-            size is determined automatically.
-        pad: padding between subplots, in inches.
-    Returns:
-        The created figure.
+    """Plot a set of images horizontally with minimal whitespace (paper-style).
+
+    Figure size is computed from image pixel dimensions.  A fixed top margin
+    (0.25") is reserved for titles so they never obscure image content.
     """
     n = len(imgs)
     if not isinstance(cmaps, list):
         cmaps = [cmaps] * n
-    figsize = (size * n, size * 6 / 5) if size is not None else None
-    fig, ax = plt.subplots(1, n, figsize=figsize, dpi=dpi)
+    if isinstance(titles, str):
+        titles = [titles]
+
+    figsize, top, width_ratios = _figure_size_for_images(imgs, dpi, ncols=n)
+    fig, ax = plt.subplots(
+        1, n, figsize=figsize, dpi=dpi, gridspec_kw={"width_ratios": width_ratios}
+    )
 
     if n == 1:
         ax = [ax]
@@ -49,11 +104,15 @@ def plot_images(
         ax[i].get_yaxis().set_ticks([])
         ax[i].get_xaxis().set_ticks([])
         ax[i].set_axis_off()
-        for spine in ax[i].spines.values():  # remove frame
+        ax[i].margins(0, 0)
+        for spine in ax[i].spines.values():
             spine.set_visible(False)
         if titles:
-            ax[i].set_title(titles[i])
-    fig.tight_layout(pad=pad)
+            ax[i].set_title(titles[i], pad=2, fontsize=12)
+
+    plt.subplots_adjust(
+        left=0.005, right=0.995, bottom=0, top=top, wspace=_WSPACE, hspace=0
+    )
     return fig
 
 
@@ -124,45 +183,40 @@ def make_matching_figure(
     path: Optional[Path] = None,
     pad: float = 0.0,
 ) -> Optional[plt.Figure]:
-    """Draw image pair with matches.
+    """Draw image pair with matches (paper-style, minimal whitespace).
 
-    Args:
-        img0: image0 as HxWx3 numpy array.
-        img1: image1 as HxWx3 numpy array.
-        mkpts0: matched points in image0 as Nx2 numpy array.
-        mkpts1: matched points in image1 as Nx2 numpy array.
-        color: colors for the matches as Nx4 numpy array.
-        titles: titles for the two subplots.
-        kpts0: keypoints in image0 as Kx2 numpy array.
-        kpts1: keypoints in image1 as Kx2 numpy array.
-        text: list of strings to display in the top-left corner of the image.
-        dpi: dots per inch of the saved figure.
-        path: if not None, save the figure to this path.
-        pad: padding around the image as a fraction of the image size.
-
-    Returns:
-        The matplotlib Figure object if path is None.
+    Figure size is computed from image pixel dimensions.  A fixed top margin
+    is reserved for titles.  Overlay text has a dark outline for readability.
     """
+    figsize, top, width_ratios = _figure_size_for_images([img0, img1], dpi, ncols=2)
+
     # draw image pair
-    fig, axes = plt.subplots(1, 2, figsize=(10, 6), dpi=dpi)
-    axes[0].imshow(img0)  # , cmap='gray')
-    axes[1].imshow(img1)  # , cmap='gray')
-    for i in range(2):  # clear all frames
+    fig, axes = plt.subplots(
+        1, 2, figsize=figsize, dpi=dpi, gridspec_kw={"width_ratios": width_ratios}
+    )
+    axes[0].imshow(img0)
+    axes[1].imshow(img1)
+    for i in range(2):
         axes[i].get_yaxis().set_ticks([])
         axes[i].get_xaxis().set_ticks([])
+        axes[i].set_axis_off()
+        axes[i].margins(0, 0)
         for spine in axes[i].spines.values():
             spine.set_visible(False)
         if titles is not None:
-            axes[i].set_title(titles[i])
+            axes[i].set_title(titles[i], pad=2, fontsize=12)
 
-    plt.tight_layout(pad=pad)
+    plt.subplots_adjust(
+        left=0.005, right=0.995, bottom=0, top=top, wspace=_WSPACE, hspace=0
+    )
 
+    # Draw all keypoints (small white dots)
     if kpts0 is not None:
         assert kpts1 is not None
-        axes[0].scatter(kpts0[:, 0], kpts0[:, 1], c="w", s=5)
-        axes[1].scatter(kpts1[:, 0], kpts1[:, 1], c="w", s=5)
+        axes[0].scatter(kpts0[:, 0], kpts0[:, 1], c="w", s=4, edgecolors="none")
+        axes[1].scatter(kpts1[:, 0], kpts1[:, 1], c="w", s=4, edgecolors="none")
 
-    # draw matches
+    # Draw match lines + matched-keypoint scatter
     if mkpts0.shape[0] != 0 and mkpts1.shape[0] != 0 and mkpts0.shape == mkpts1.shape:
         fig.canvas.draw()
         transFigure = fig.transFigure.inverted()
@@ -174,30 +228,27 @@ def make_matching_figure(
                 (fkpts0[i, 1], fkpts1[i, 1]),
                 transform=fig.transFigure,
                 c=color[i],
-                linewidth=2,
+                linewidth=1.5,
             )
             for i in range(len(mkpts0))
         ]
 
-        # freeze the axes to prevent the transform to change
         axes[0].autoscale(enable=False)
         axes[1].autoscale(enable=False)
 
-        axes[0].scatter(mkpts0[:, 0], mkpts0[:, 1], c=color[..., :3], s=4)
-        axes[1].scatter(mkpts1[:, 0], mkpts1[:, 1], c=color[..., :3], s=4)
+        # Matched keypoints — small colored dots
+        axes[0].scatter(
+            mkpts0[:, 0], mkpts0[:, 1], c=color[..., :3], s=5, edgecolors="none"
+        )
+        axes[1].scatter(
+            mkpts1[:, 0], mkpts1[:, 1], c=color[..., :3], s=5, edgecolors="none"
+        )
 
-    # put txts
-    txt_color = "k" if img0[:100, :200].mean() > 200 else "w"
-    fig.text(
-        0.01,
-        0.99,
-        "\n".join(text),
-        transform=fig.axes[0].transAxes,
-        fontsize=15,
-        va="top",
-        ha="left",
-        color=txt_color,
-    )
+    # Overlay match count with stroke so it's readable on any background
+    if text:
+        _stroked_text(
+            axes[0], 0.01, 0.99, "\n".join(text), fontsize=12, va="top", ha="left"
+        )
 
     # save or return figure
     if path:
@@ -229,20 +280,27 @@ def error_colormap(err: np.ndarray, thr: float, alpha: float = 1.0) -> np.ndarra
 
 
 def fig2im(fig: matplotlib.figure.Figure) -> np.ndarray:
-    """
-    Convert a matplotlib figure to a numpy array with RGB values.
+    """Convert a matplotlib figure to a numpy RGB array.
 
-    Args:
-        fig: A matplotlib figure.
-
-    Returns:
-        A numpy array with shape (height, width, 3) and dtype uint8 containing
-        the RGB values of the figure.
+    Uses an in-memory PNG buffer so the output is immune to HiDPI
+    (Retina) canvas-vs-buffer mismatches.  ``bbox_inches=None`` keeps the
+    exact figure size so that figures with different title lengths stay
+    pixel-identical in width.
     """
-    fig.canvas.draw()
-    (width, height) = fig.canvas.get_width_height()
-    buf_ndarray = np.frombuffer(fig.canvas.tostring_rgb(), dtype="u1")
-    return buf_ndarray.reshape(height, width, 3)
+    buf = io.BytesIO()
+    fig.savefig(
+        buf,
+        format="png",
+        bbox_inches=None,
+        pad_inches=0,
+        dpi=fig.dpi,
+        facecolor=fig.get_facecolor(),
+    )
+    buf.seek(0)
+    rgba = plt.imread(buf)
+    if rgba.shape[-1] == 4:
+        return (rgba[:, :, :3] * 255).astype(np.uint8)
+    return (rgba * 255).astype(np.uint8)
 
 
 def draw_matches_core(
@@ -255,32 +313,15 @@ def draw_matches_core(
     texts: Optional[List[str]] = None,
     dpi: int = 150,
     path: Optional[str] = None,
-    pad: float = 0.5,
+    pad: float = 0.0,
 ) -> np.ndarray:
-    """
-    Draw matches between two images.
-
-    Args:
-        mkpts0: List of matches from the first image, with shape (N, 2)
-        mkpts1: List of matches from the second image, with shape (N, 2)
-        img0: First image, with shape (H, W, 3)
-        img1: Second image, with shape (H, W, 3)
-        conf: Confidence values for the matches, with shape (N,)
-        titles: Optional list of title strings for the plot
-        dpi: DPI for the saved image
-        path: Optional path to save the image to. If None, the image is not saved.
-        pad: Padding between subplots
-
-    Returns:
-        The figure as a numpy array with shape (height, width, 3) and dtype uint8
-        containing the RGB values of the figure.
-    """
+    """Draw matches between two images."""
     thr = 0.5
     color = error_colormap(1 - conf, thr, alpha=0.1)
-    text = [
-        # "image name",
-        f"#Matches: {len(mkpts0)}",
-    ]
+    if texts:
+        text = list(texts)
+    else:
+        text = [f"#Matches: {len(mkpts0)}"]
     if path:
         fig2im(
             make_matching_figure(
@@ -293,7 +334,6 @@ def draw_matches_core(
                 text=text,
                 path=path,
                 dpi=dpi,
-                pad=pad,
             )
         )
     else:
@@ -306,7 +346,6 @@ def draw_matches_core(
                 color,
                 titles=titles,
                 text=text,
-                pad=pad,
                 dpi=dpi,
             )
         )
@@ -318,50 +357,38 @@ def draw_image_pairs(
     text: List[str] = [],
     dpi: int = 75,
     path: Optional[str] = None,
-    pad: float = 0.5,
+    pad: float = 0.0,
 ) -> np.ndarray:
-    """Draw image pair horizontally.
+    """Draw image pair horizontally with minimal whitespace (paper-style).
 
-    Args:
-        img0: First image, with shape (H, W, 3)
-        img1: Second image, with shape (H, W, 3)
-        text: List of strings to print. Each string is a new line.
-        dpi: DPI of the figure.
-        path: Path to save the image to. If None, the image is not saved and
-            the function returns the figure as a numpy array with shape
-            (height, width, 3) and dtype uint8 containing the RGB values of the
-            figure.
-        pad: Padding between subplots
-
-    Returns:
-        The figure as a numpy array with shape (height, width, 3) and dtype uint8
-        containing the RGB values of the figure, or None if path is not None.
+    Figure size is computed from image pixel dimensions.  A fixed top margin
+    is reserved for overlay text.
     """
-    # draw image pair
-    fig, axes = plt.subplots(1, 2, figsize=(10, 6), dpi=dpi)
-    axes[0].imshow(img0)  # , cmap='gray')
-    axes[1].imshow(img1)  # , cmap='gray')
-    for i in range(2):  # clear all frames
+    figsize, top, width_ratios = _figure_size_for_images([img0, img1], dpi, ncols=2)
+
+    fig, axes = plt.subplots(
+        1, 2, figsize=figsize, dpi=dpi, gridspec_kw={"width_ratios": width_ratios}
+    )
+    axes[0].imshow(img0)
+    axes[1].imshow(img1)
+    for i in range(2):
         axes[i].get_yaxis().set_ticks([])
         axes[i].get_xaxis().set_ticks([])
+        axes[i].set_axis_off()
+        axes[i].margins(0, 0)
         for spine in axes[i].spines.values():
             spine.set_visible(False)
-    plt.tight_layout(pad=pad)
 
-    # put txts
-    txt_color = "k" if img0[:100, :200].mean() > 200 else "w"
-    fig.text(
-        0.01,
-        0.99,
-        "\n".join(text),
-        transform=fig.axes[0].transAxes,
-        fontsize=15,
-        va="top",
-        ha="left",
-        color=txt_color,
+    plt.subplots_adjust(
+        left=0.005, right=0.995, bottom=0, top=top, wspace=_WSPACE, hspace=0
     )
 
-    # save or return figure
+    # Stroked overlay text so it's readable on any background
+    if text:
+        _stroked_text(
+            axes[0], 0.01, 0.99, "\n".join(text), fontsize=12, va="top", ha="left"
+        )
+
     if path:
         plt.savefig(str(path), bbox_inches="tight", pad_inches=0)
         plt.close()
@@ -374,12 +401,12 @@ def display_keypoints(pred: dict, titles: List[str] = []):
     img1 = pred["image1_orig"]
     output_keypoints = plot_images([img0, img1], titles=titles, dpi=300)
     if "keypoints0_orig" in pred.keys() and "keypoints1_orig" in pred.keys():
-        plot_keypoints([pred["keypoints0_orig"], pred["keypoints1_orig"]])
+        plot_keypoints([pred["keypoints0_orig"], pred["keypoints1_orig"]], ps=4)
         text = (
             f"# keypoints0: {len(pred['keypoints0_orig'])} \n"
             + f"# keypoints1: {len(pred['keypoints1_orig'])}"
         )
-        add_text(0, text, fs=15)
+        add_text(0, text, fs=12)
     output_keypoints = fig2im(output_keypoints)
     return output_keypoints
 


### PR DESCRIPTION
## Summary

### LISRD matcher fixes
- **Bug fix**: `_lisrd_matcher` argument order was wrong — descriptors and meta-descriptors were swapped, causing einsum dimension mismatch (128 vs 1024)
- **3 keypoint detectors**: SuperPoint (default), ALIKED, SIFT — configurable via `detector` option
- Configs renamed: `lisrd-superpoint` / `lisrd-aliked` / `lisrd-sift`

### Visualization overhaul
- **Dynamic figure sizing** from image pixel dimensions — eliminates all whitespace
- **width_ratios** for consistent layout with different-sized images
- **Stroked text overlay** (path effects) — readable on any background
- **HiDPI-safe `fig2im`** via PNG buffer (fixes Retina canvas mismatch)
- Title in top margin instead of overlaying image content
- Smaller keypoint markers, appropriate font sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)